### PR TITLE
DO NOT MERGE: revert to Golang 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CrunchyData/pg_tileserv
 
-go 1.23.0
+go 1.22.0
 
 toolchain go1.24.2
 


### PR DESCRIPTION
This is just to get automated build tests to run.